### PR TITLE
Delete "use strict"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-"use strict"
-
 // Permissions code: 67584
 // Send messages, read message history
 

--- a/schism/corpus.js
+++ b/schism/corpus.js
@@ -1,5 +1,3 @@
-"use strict"
-
 const fs = require("fs").promises
     , s3 = require("./s3")
 

--- a/schism/defaults.js
+++ b/schism/defaults.js
@@ -1,5 +1,3 @@
-"use strict"
-
 module.exports = {
 	PREFIX: "|",
 	EMBED_COLORS: {

--- a/schism/embeds.js
+++ b/schism/embeds.js
@@ -1,5 +1,3 @@
-"use strict"
-
 const { RichEmbed } = require("discord.js")
 
 const embedColors = (process.env.EMBED_COLORS)

--- a/schism/help.js
+++ b/schism/help.js
@@ -1,5 +1,3 @@
-"use strict"
-
 const prefix = process.env.PREFIX || require("./defaults").PREFIX
 
 module.exports = {

--- a/schism/markov.js
+++ b/schism/markov.js
@@ -1,5 +1,3 @@
-"use strict"
-
 const regex = require("./regex")
 
 var corpusUtils

--- a/schism/regex.js
+++ b/schism/regex.js
@@ -1,5 +1,3 @@
-"use strict"
-
 module.exports = {
 	/**
 	 * All instances of <@[userID]>, including the outer characters.

--- a/schism/s3.js
+++ b/schism/s3.js
@@ -1,5 +1,3 @@
-"use strict"
-
 const AWS  = require("aws-sdk")
     , path = require("path")
 

--- a/schism/scrape.js
+++ b/schism/scrape.js
@@ -1,5 +1,3 @@
-"use strict"
-
 const prefix = process.env.PREFIX || require("./defaults").PREFIX
 const escapedPrefix = _escape(prefix)
 


### PR DESCRIPTION
It has come to my attention (thank you, Qix!) that strict mode is the default mode since ES2015, so `"use strict"` isn't necessary anymore.