### PR TITLE
Greater user control

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ A Markov-chain-based Discord bot that keeps a separate Markov chain for each use
 
 ## TODO
 - Keep data per server separate. Partially patched in at the moment, but needs a better solution.
-- "forget" and "download" commands to let users download and delete their own data
+- "download" command so users don't have to personally ask me for a copy of their data
 - Message rate limiting to mitigate spam
-- Webhook rate limiter that actually works
+- Webhook rate limiter that actually works (maybe it works now???)
 - _So ein mist!_ `index.js` is longer than 1,000 lines again. Refactor to keep all files under 1,000 lines.
 - Setup guide for running your own copy of Schism
 - Setup commands for configuring Schism in new servers

--- a/eula.txt
+++ b/eula.txt
@@ -1,0 +1,8 @@
+TL;DR: In order to imitate you, Schism stores your messages.
+
+Schism's main functionality is to imitate users. To do this, Schism collects and stores the text contents of the messages you send in /r/Ooer's general chat. When you tell Schism to imitate you, your stored messages are processed through an algorithm designed to generate new sentences that sound like you. The text content of the messages Schism collects are kept by <@206235904644349953>, indefinitely, on a remote file server based in the US. <@206235904644349953> reserves the right to erase part or all of your data at any time if it is found to be in violation of Discord's ToS, /r/Ooer's rules, and/or US law.
+
+You, at any time, have the right to:
+1) request a copy of your data.
+2) request the deletion of your data.
+3. revoke your consent to this agreement, at which point Schism's ability to imitate you will be paused. Note that revoking your agreement does not automatically delete your data.

--- a/eula.txt
+++ b/eula.txt
@@ -1,6 +1,6 @@
 TL;DR: In order to imitate you, Schism stores your messages.
 
-Schism's main functionality is to imitate users. To do this, Schism collects and stores the text contents of the messages you send in /r/Ooer's general chat. When you tell Schism to imitate you, your stored messages are processed through an algorithm designed to generate new sentences that sound like you. The text content of the messages Schism collects are kept by <@206235904644349953>, indefinitely, on a remote file server based in the US. <@206235904644349953> reserves the right to erase part or all of your data at any time if it is found to be in violation of Discord's ToS, /r/Ooer's rules, and/or US law.
+Schism's main functionality is to imitate users. To do this, Schism collects and stores the text contents of the messages you send in select channels. When you tell Schism to imitate you, your stored messages are processed through an algorithm designed to generate new sentences that sound like you. The text content of the messages Schism collects are kept by <@206235904644349953>, indefinitely, on a remote file server based in the US. <@206235904644349953> reserves the right to erase part or all of your data at any time if it is found to be in violation of Discord's ToS, /r/Ooer's rules, and/or US law.
 
 You, at any time, have the right to:
 1) request a copy of your data.

--- a/schism/embeds.js
+++ b/schism/embeds.js
@@ -1,17 +1,85 @@
+const fs = require("fs")
 const { RichEmbed } = require("discord.js")
-const colors = require("./config").EMBED_COLORS
-
+const config = require("./config")
+const colors = config.EMBED_COLORS
+const prefix = config.PREFIX
 
 /**
  * Generate a Discord Rich Embed message.
  * 
  * @param {string} str - message to print
+ * @param {DiscordUser} author? - (optional) author to assign to the embed
  * @return {RichEmbed} Discord Rich Embed object
  */
-function standard(str) {
+function standard(str, author) {
+	const embed = new RichEmbed()
+		.setColor(colors.normal)
+		.setDescription(str)
+
+	if (author) {
+		embed.setAuthor(author.tag, author.avatarURL)
+	}
+
+	return embed
+}
+
+
+function consent(user) {
 	return new RichEmbed()
 		.setColor(colors.normal)
-		.addField("Schism", str)
+		.setAuthor(user.tag, user.avatarURL)
+		.setTitle(`${user.tag}, did you agree to Schism's End User License Agreement?`)
+		.setDescription(`View the full End User License Agreement with \`${prefix}eula\`, then make your decision with \`${prefix}agree\` or \`${prefix}disagree\`.`)
+		.setFooter("Schism keeps your messages to gain an impression of how you speak. You must agree to the End User License Agreement before Schism can imitate you.")
+}
+
+
+function agree(user) {
+	return new RichEmbed()
+		.setColor(colors.normal)
+		.setAuthor(user.tag, user.avatarURL)
+		.setDescription("You have agreed to Schism's End User License Agreement. You can now make Schism imitate you!")
+		.setFooter(`View the full EULA: ${prefix}eula • Revoke consent: ${prefix}disagree`)
+}
+
+
+function disagree(user) {
+	return new RichEmbed()
+		.setColor(colors.normal)
+		.setAuthor(user.tag, user.avatarURL)
+		.setDescription("You have disagreed to Schism's End User License Agreement. Schism will no longer be able to imitate you.")
+		.setFooter(`View the full EULA: ${prefix}eula • Restore consent: ${prefix}agree`)
+}
+
+
+function confirmForget(caller, forgetee) {
+	const self = caller.id === forgetee.id
+	return new RichEmbed()
+		.setColor(colors.normal)
+		.setAuthor(caller.tag, caller.avatarURL)
+		.setTitle(`Are you sure you want Schism to forget ${self ? "you" : `**${forgetee.tag}**`}?`)
+		.setDescription(`To confirm, do \`${prefix}confirmforget${self ? "" : ` @${forgetee.username}`}\` within the next 30 seconds.`)
+		.setFooter(`${self ? "Your" : "This user's"} data will be permanently erased from Schism's servers.`)
+
+}
+
+
+function confirmationExpired(caller, forgetee) {
+	const self = caller.id === forgetee.id
+	return new RichEmbed()
+		.setColor(colors.normal)
+		.setAuthor(caller.tag, caller.avatarURL)
+		.setTitle("No pending confirmation")
+		.setDescription(`There is no pending confirmation for you to delete ${self ? "your" : `**${forgetee.tag}**'s`} data. This means that either the confirmation window has expired, or that you have never requested for Schism to forget ${self ? "you" : `**${forgetee.tag}**`}.`)
+}
+
+
+function forgot(caller, forgetee) {
+	return new RichEmbed()
+		.setColor(colors.normal)
+		.setAuthor(caller.tag, caller.avatarURL)
+		.setTitle(`Forgot **${forgetee.tag}**.`)
+		.setDescription(`This user's data has been permanently erased from Schism's servers.`)
 }
 
 
@@ -24,7 +92,7 @@ function standard(str) {
 function error(err) {
 	return new RichEmbed()
 		.setColor(colors.error)
-		.addField("Error", err)
+		.setDescription(err)
 }
 
 
@@ -45,13 +113,28 @@ const xok = new RichEmbed()
  */
 const code = new RichEmbed()
 	.setTitle("Schism is open source!")
-	.addField("View the code, file issues, and make pull requests to help improve Schism.", "https://github.com/the-garlic-os/schism")
+	.addField("View the code, file issues, and make pull requests to help improve Schism.", "https://github.com/Grosserly/schism")
 	.setFooter("Please help me. I'm begging you.")
+
+
+/**
+ * A pre-made embed containing Schism's End User License Agreement.
+ */
+const eula = new RichEmbed()
+	.setTitle("Schism's End User License Agreement")
+	.setDescription(fs.readFileSync("./eula.txt")) // Yes, this will break if it pushes the embed over 6,000 characters
 
 
 module.exports = {
 	standard,
+	consent,
+	agree,
+	disagree,
+	forgot,
+	confirmForget,
+	confirmationExpired,
 	error,
 	xok,
-	code
+	code,
+	eula
 }

--- a/schism/expirable-set.js
+++ b/schism/expirable-set.js
@@ -1,0 +1,23 @@
+/**
+ * A Set whose elements automatically self-delete a given time after being added.
+ */
+class ExpirableSet extends Set {
+	/**
+	 * Add a value to the Set with an expiration date.
+	 * 
+	 * @param {any} value - value to add to the Set
+	 * @param {number} lifespan=30000 - time, in ms, before the value is deleted from the Set
+	 * @return {ExpirableSet} self
+	 */
+	addWithExpiry(value, lifespan=30000) {
+		this.add(value)
+
+		setTimeout( () => {
+			this.delete(value)
+		}, lifespan)
+
+		return this
+	}
+}
+
+module.exports = ExpirableSet

--- a/schism/help.js
+++ b/schism/help.js
@@ -9,19 +9,19 @@ module.exports = {
 
 	, imitate: {
 		admin: false,
-		desc: `Imitate a user.`,
-		syntax: `${prefix}imitate <user>`
+		desc: `Imitate yourself.`,
+		syntax: `${prefix}imitate`
 	}
 
 	, intimidate: {
 		admin: false,
-		desc: `**IMITATE A USER.**`,
-		syntax: `${prefix}intimidate <user>`
+		desc: `**IMITATE YOURSELF.**`,
+		syntax: `${prefix}intimidate`
 	}
 
 	, save: {
 		admin: true,
-		desc: `Upload all unsaved cache to S3.`,
+		desc: `Upload unsaved cache to S3.`,
 		syntax: `${prefix}save ["all"]`
 	}
 
@@ -71,5 +71,29 @@ module.exports = {
 		admin: false,
 		desc: `Get information on how to find Schism on GitHub.`,
 		syntax: `${prefix}[code|github|source]`
+	}
+
+	, forget: {
+		admin: false,
+		desc: `Remove your data from Schism.`,
+		syntax: `${prefix}forget`
+	}
+
+	, eula: {
+		admin: false,
+		desc: `View Schism's End User License Agreement.`,
+		syntax: `${prefix}eula`
+	}
+
+	, agree: {
+		admin: false,
+		desc: `Agree to Schism's EULA.`,
+		syntax: `${prefix}agree`
+	}
+
+	, disagree: {
+		admin: false,
+		desc: `Disagree to Schism's EULA (Schism will not be able to imitate you).`,
+		syntax: `${prefix}disagree`
 	}
 }

--- a/schism/learning.js
+++ b/schism/learning.js
@@ -1,5 +1,6 @@
 const config = require("./config.js")
 const escapedPrefix = _escape(config.PREFIX)
+const { consenting } = require("./corpus")
 
 var client
 var corpusUtils
@@ -142,6 +143,12 @@ async function scrape(channel, goal) {
 			// Message has text (sometimes it can just be a picture)
 			if (message.content && message.author.id !== client.user.id) {
 				const authorID = message.author.id
+
+				// Filter out messages from users to haven't agreed to the EULA
+				if (!consenting.has(authorID)) {
+					return
+				}
+
 				if (!scrape_buffers[authorID]) {
 					scrape_buffers[authorID] = ""
 				}
@@ -189,6 +196,10 @@ const learnFrom_buffers = {}
  */
 function learnFrom(message) {
 	const authorID = message.author.id
+
+	if (!consenting.has(authorID)) {
+		return
+	}
 
 	if (_isNaughty(message.content)) {
 		const msg = `Bad word detected.

--- a/schism/markov.js
+++ b/schism/markov.js
@@ -1,4 +1,3 @@
-const Markov = require("markov-strings").default
 var corpusUtils
 
 

--- a/schism/tracker-set.js
+++ b/schism/tracker-set.js
@@ -1,0 +1,19 @@
+/**
+ * A Set that keeps track of whether it has been modified.
+ */
+class TrackerSet extends Set {
+	add(value) {
+		this.modified = true
+		super.add(value)
+		return this
+	}
+
+	delete(value) {
+		this.modified = true
+		super.delete(value)
+		return this
+	}
+}
+
+
+module.exports = TrackerSet


### PR DESCRIPTION
This update gives users more control over their data. Now, before a user can use Schism, they must agree to an End User License Agreement that covers how Schism stores and uses their data, along with the rights they have to their data.
Users now also have the ability to delete their data from Schism. This action is permanent and irreversible, so extra caution is taken to make sure that users can't do this by accident, while still keeping the process easy.