### PR TITLE
Fix Gibberish argument validation

### DIFF
--- a/src/commands/text/gibberish.ts
+++ b/src/commands/text/gibberish.ts
@@ -2,11 +2,10 @@ import type { CommandoClient, CommandoMessage } from "discord.js-commando";
 
 import { gibberish } from "../../modules/gibberish";
 import { Command } from "discord.js-commando";
-import { triggerAsyncId } from "async_hooks";
 
 
 interface GibberishCommandArguments {
-    text: string;
+    text: string[];
 }
 
 
@@ -29,16 +28,15 @@ export default class GibberishCommand extends Command {
                     prompt: "Text to feed into the gibberish machine",
                     type: "string",
                     infinite: true,
-                    parse: (_: any, message: CommandoMessage): string => {
-                        return message.argString.substring(1);
-                    },
                 },
             ],
 		});
     }
     
 
-    run(message: CommandoMessage, { text }: GibberishCommandArguments): null {
+    run(message: CommandoMessage, { text: words }: GibberishCommandArguments): null {
+        const text = words.join(" ");
+
         if (text.length < 4) {
             message.reply("the input should be least 4 characters to generate gibberish.");
             return null;


### PR DESCRIPTION
Users were encountering a bogus validation error when they didn't give the Gibberish command at least four words. The Gibberish command is supposed make sure that the input has at least 4 characters, not 4 words. The problem came from a misunderstanding in how Commando's infinite argument collection works. Turns out it's impossible to actually get a string from infinite arguments (whyyy Commando?). So instead now the command just .join()'s the array of arguments when it gets it.