### PR TITLE
Build Markov chain generators in the executor

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,7 +12,7 @@ import config
 import os
 import logging
 import aiohttp
-from functools import lru_cache
+from async_lru import alru_cache
 from utils.exceptions import NoDataError
 from utils import ParrotMarkov, regex, tag
 from database.corpus_manager import CorpusManager
@@ -166,8 +166,8 @@ class Parrot(commands.AutoShardedBot):
         logging.info("Save complete.")
 
 
-    @lru_cache(maxsize=int(config.MODEL_CACHE_SIZE))
-    def get_model(self, user_id: int) -> ParrotMarkov:
+    @alru_cache(maxsize=int(config.MODEL_CACHE_SIZE))
+    async def get_model(self, user_id: int) -> ParrotMarkov:
         """ Get a Markov model by user ID. """
         res = self.db.execute(
             "SELECT content FROM messages WHERE user_id = ?", (user_id,)
@@ -179,7 +179,7 @@ class Parrot(commands.AutoShardedBot):
         # messages = [row[0] for row in res.fetchall()]
         if len(messages) == 0:
             raise NoDataError("Speak more! No data on this user.")
-        return ParrotMarkov(messages)
+        return await ParrotMarkov.new(messages)
 
 
     def validate_message(self, message: Message) -> bool:

--- a/commands/text.py
+++ b/commands/text.py
@@ -148,7 +148,7 @@ class Text(commands.Cog):
                         "😕 Couldn't find a gibberizeable message"
                     )
 
-        model = GibberishMarkov(text)
+        model = await GibberishMarkov.new(text)
 
         # Generate gibberish;
         # try up to 10 times to make it not the same as the source text.

--- a/commands/text.py
+++ b/commands/text.py
@@ -64,7 +64,7 @@ class Text(commands.Cog):
         # Fetch this user's model.
         # May throw a NotRegistered or NoData error, which we'll just let the
         # error handler deal with.
-        model = self.bot.get_model(user.id)
+        model = await self.bot.get_model(user.id)
         sentence = model.make_short_sentence(500) or "Error"
         name = f"Not {user.display_name}"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -138,6 +138,20 @@ six = ">=1.6.1,<2.0"
 wheel = ">=0.23.0,<1.0"
 
 [[package]]
+name = "async-lru"
+version = "2.0.4"
+description = "Simple LRU cache for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "async-lru-2.0.4.tar.gz", hash = "sha256:b8a59a5df60805ff63220b2a0c5b5393da5521b113cd5465a44eb037d81a5627"},
+    {file = "async_lru-2.0.4-py3-none-any.whl", hash = "sha256:ff02944ce3c288c5be660c42dbcca0742b32c3b279d6dceda655190240b99224"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
@@ -731,6 +745,17 @@ files = [
 ]
 
 [[package]]
+name = "typing-extensions"
+version = "4.7.1"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
+]
+
+[[package]]
 name = "unidecode"
 version = "1.3.6"
 description = "ASCII transliterations of Unicode text"
@@ -845,4 +870,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7eb31455207a77f813176b48e72624926a58441f2ee8290feead36c0971b00f7"
+content-hash = "7574d5a1090b002d6d5fe35686d52be3347c2025bddccfff633851053a055972"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ markovify = "^0.9.4"
 Pillow = "^10.0.0"
 PyYAML = "^6.0.1"
 asyncio-atexit = "^1.0.1"
+async-lru = "^2.0.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,5 @@
 from utils.tag import tag
+from utils.executor_function import executor_function
 from utils.fetch_webhook import fetch_webhook
 from utils.history_crawler import HistoryCrawler
 from utils.parrot_embed import ParrotEmbed
@@ -6,6 +7,7 @@ from utils.parrot_markov import GibberishMarkov, ParrotMarkov
 
 
 __all__ = [
+    "executor_function",
     "fetch_webhook",
     "HistoryCrawler",
     "GibberishMarkov", "ParrotMarkov",

--- a/utils/executor_function.py
+++ b/utils/executor_function.py
@@ -1,3 +1,10 @@
+"""
+crimsoBOT run_in_executor() decorator
+https://github.com/crimsobot/crimsoBOT/blob/09abe19fd1ea23ed670b5e68a68dac1adc677092/crimsobot/utils/tools.py#L27
+MIT License
+Copyright (c) 2019 crimso, williammck
+"""
+
 from typing import Any, Awaitable, Callable
 
 import asyncio

--- a/utils/executor_function.py
+++ b/utils/executor_function.py
@@ -1,0 +1,13 @@
+from typing import Any, Awaitable, Callable
+
+import asyncio
+import functools
+
+
+def executor_function(sync_function: Callable) -> Callable:
+    @functools.wraps(sync_function)
+    async def sync_wrapper(*args, **kwargs) -> Awaitable[Any]:
+        loop = asyncio.get_event_loop()
+        reconstructed_function = functools.partial(sync_function, *args, **kwargs)
+        return await loop.run_in_executor(None, reconstructed_function)
+    return sync_wrapper

--- a/utils/image.py
+++ b/utils/image.py
@@ -6,26 +6,15 @@ Copyright (c) 2019 crimso, williammck
 """
 
 from io import BytesIO
-from typing import Any, Awaitable, Callable, List, Mapping, Optional, Tuple
+from typing import Any, Callable, List, Mapping, Optional, Tuple
 from discord import User
 
 import logging
 import aiohttp
-import asyncio
-import functools
 from PIL import Image, ImageSequence, ImageOps
 
 from assets import GIF_RULES, IMAGE_RULES
-from utils import tag
-
-
-def executor_function(sync_function: Callable) -> Callable:
-    @functools.wraps(sync_function)
-    async def sync_wrapper(*args, **kwargs) -> Awaitable[Any]:
-        loop = asyncio.get_event_loop()
-        reconstructed_function = functools.partial(sync_function, *args, **kwargs)
-        return await loop.run_in_executor(None, reconstructed_function)
-    return sync_wrapper
+from utils import executor_function, tag
 
 
 def gif_frame_transparency(img: Image.Image) -> Image.Image:

--- a/utils/parrot_markov.py
+++ b/utils/parrot_markov.py
@@ -2,7 +2,7 @@ from typing import List
 
 import markovify
 import random
-from util import executor_function
+from utils import executor_function
 
 
 class ParrotMarkov(markovify.Text):

--- a/utils/parrot_markov.py
+++ b/utils/parrot_markov.py
@@ -2,9 +2,11 @@ from typing import List
 
 import markovify
 import random
+from util import executor_function
 
 
 class ParrotMarkov(markovify.Text):
+    @executor_function
     def __init__(self, corpus: List[str]):
         super().__init__(
             input_text=corpus,
@@ -19,6 +21,7 @@ class GibberishMarkov(markovify.Text):
     Feed the corpus to the Markov model character-by-character instead of
     word-by-word for extra craziness!
     """
+    @executor_function
     def __init__(self, text: str):
         super().__init__(
             None,

--- a/utils/parrot_markov.py
+++ b/utils/parrot_markov.py
@@ -6,7 +6,6 @@ from utils import executor_function
 
 
 class ParrotMarkov(markovify.Text):
-    @executor_function
     def __init__(self, corpus: List[str]):
         super().__init__(
             input_text=corpus,
@@ -15,13 +14,17 @@ class ParrotMarkov(markovify.Text):
             well_formed=False,
         )
 
+    @classmethod
+    @executor_function
+    def new(cls, *args, **kwargs):
+        return cls(*args, **kwargs)
+
 
 class GibberishMarkov(markovify.Text):
     """
     Feed the corpus to the Markov model character-by-character instead of
     word-by-word for extra craziness!
     """
-    @executor_function
     def __init__(self, text: str):
         super().__init__(
             None,
@@ -31,6 +34,11 @@ class GibberishMarkov(markovify.Text):
             well_formed=False,
         )
         self.original = text
+
+    @classmethod
+    @executor_function
+    def new(cls, *args, **kwargs):
+        return cls(*args, **kwargs)
 
     def word_join(self, words: List[str]) -> str:
         # The generator usually puts spaces between each entry in the list


### PR DESCRIPTION
Realized that these things block the main thread for quite a long time when they run. Using crimsoBOT's cool [`@executor_function`](https://github.com/crimsobot/crimsoBOT/blob/09abe19fd1ea23ed670b5e68a68dac1adc677092/crimsobot/utils/tools.py#L27) decorator, we can put the constructors for the Markov chain generators in a separate thread. The results are immediately noticable:

Setup: say |imitate me when you know you aren't in the cache. Then immediately say |ping.  
Before: Parrot doesn't say "pong" until it finishes building the Markov chain generator and sends its imitation message.  
After: Parrot says "pong" immediately, even though the Markov chain generator is still in the middle of being built.