### PR TITLE
Don't imitate unregistered users even if they have data

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Set, Union
 from discord import (
-    Activity, ActivityType, AllowedMentions, ChannelType, Message, Intents
+    Activity, ActivityType, AllowedMentions, ChannelType, Message, Intents, User
 )
 import discord
 from discord.ext import commands
@@ -167,19 +167,10 @@ class Parrot(commands.AutoShardedBot):
 
 
     @alru_cache(maxsize=int(config.MODEL_CACHE_SIZE))
-    async def get_model(self, user_id: int) -> ParrotMarkov:
+    async def get_model(self, user: User) -> ParrotMarkov:
         """ Get a Markov model by user ID. """
-        res = self.db.execute(
-            "SELECT content FROM messages WHERE user_id = ?", (user_id,)
-        )
-        rows = res.fetchall()
-        messages = []
-        for row in rows:
-            messages.append(row[0])
-        # messages = [row[0] for row in res.fetchall()]
-        if len(messages) == 0:
-            raise NoDataError("Speak more! No data on this user.")
-        return await ParrotMarkov.new(messages)
+        corpus = self.corpora.get(user)
+        return await ParrotMarkov.new(corpus)
 
 
     def validate_message(self, message: Message) -> bool:

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,6 @@ import os
 import logging
 import aiohttp
 from async_lru import alru_cache
-from utils.exceptions import NoDataError
 from utils import ParrotMarkov, regex, tag
 from database.corpus_manager import CorpusManager
 from database.avatar_manager import AvatarManager

--- a/commands/quickstart.py
+++ b/commands/quickstart.py
@@ -5,7 +5,7 @@ from bot import Parrot
 import asyncio
 import discord
 from discord.ext import commands
-from utils import HistoryCrawler, ParrotEmbed, tag
+from utils import HistoryCrawler, ParrotEmbed
 from utils.exceptions import AlreadyScanning, NotRegisteredError, UserPermissionError
 from utils.checks import is_admin
 from utils.converters import Userlike
@@ -37,7 +37,7 @@ class Quickstart(commands.Cog):
                 icon_url="https://i.gifer.com/ZZ5H.gif",  # Loading spinner
             )
             embed.set_footer(
-                text=f"Scanning for {tag(user)}",
+                text=f"Scanning for {user}",
                 icon_url=user.display_avatar.url,
             )
             await status_message.edit(embed=embed)
@@ -71,7 +71,7 @@ class Quickstart(commands.Cog):
             if ctx.author == user:
                 raise AlreadyScanning("❌ Quickstart is already running!")
             raise AlreadyScanning(
-                f"❌ Quickstart is already running for {tag(user)}!"
+                f"❌ Quickstart is already running for {user.mention}!"
             )
 
         self.ongoing_scans.add(user.id)
@@ -104,7 +104,7 @@ class Quickstart(commands.Cog):
                 title="Quickstart is scanning",
                 description=(
                     "Parrot is now scanning this server and learning from "
-                    f"{tag(name)} past messages.\nThis could take a few minutes."
+                    f"{name} past messages.\nThis could take a few minutes."
                     "\nCheck your DMs to see its progress."
                 )
             ), reference=ctx.message)
@@ -148,7 +148,7 @@ class Quickstart(commands.Cog):
 
             # Update the status embed one last time, but DELETE it this time and
             #   post a brand new one so that the user gets a new notification.
-            name = "you" if ctx.author == user else f"{tag(user)}"
+            name = "you" if ctx.author == user else f"{user.mention}"
             embed = ParrotEmbed(
                 description=(
                     f"**Scan complete.**\nCollected "
@@ -157,12 +157,12 @@ class Quickstart(commands.Cog):
             )
             embed.set_author(name="✅ Quickstart")
             embed.set_footer(
-                text=f"Scanning for {tag(user)}",
+                text=f"Scanning for {user.mention}",
                 icon_url=user.display_avatar.url,
             )
             if crawler.num_collected == 0:
                 embed.description += (
-                    f"\n😕 Couldn't find any messages from {tag(name)}."
+                    f"\n😕 Couldn't find any messages from {name}."
                 )
                 embed.color = ParrotEmbed.colors["red"]
             await asyncio.gather(
@@ -179,8 +179,8 @@ class Quickstart(commands.Cog):
     def assert_registered(self, user: Union[User, Member]) -> None:
         if not user.bot and user.id not in self.bot.registered_users:
             raise NotRegisteredError(
-                f"User {user} is not opted in to Parrot. To opt in, do the "
-                f"`{self.bot.command_prefix}register` command."
+                f"User {user.mention} is not opted in to Parrot. To opt in, do "
+                f"the `{self.bot.command_prefix}register` command."
             )
 
 

--- a/commands/registration.py
+++ b/commands/registration.py
@@ -113,7 +113,7 @@ class Registration(commands.Cog):
         if who.bot:
             return await ctx.send("✅ Bots do not need to be registered.")
         if who.id in self.bot.registered_users:
-            await ctx.send(f"✅ {subject_verb} are currently registered with Parrot.")
+            await ctx.send(f"✅ {subject_verb} currently registered with Parrot.")
         else:
             await ctx.send(f"❌ {subject_verb} not currently registered with Parrot.")
 

--- a/commands/registration.py
+++ b/commands/registration.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 from bot import Parrot
-from utils import ParrotEmbed
+from utils import ParrotEmbed, tag
 from utils.converters import Userlike
 from utils.exceptions import FriendlyError
 
@@ -101,16 +101,20 @@ class Registration(commands.Cog):
         brief="Check if you're registered with Parrot.",
     )
     @commands.cooldown(2, 4, commands.BucketType.user)
-    async def status(self, ctx: commands.Context) -> None:
+    async def status(self, ctx: commands.Context, who: Userlike=None) -> None:
         """
         Check if you're registered with Parrot.
         You need to be registered for Parrot to be able to analyze your messages
         and imitate you.
         """
-        if ctx.author.id in self.bot.registered_users:
-            await ctx.send("✅ You are currently registered with Parrot.")
+        subject_verb = "You are"
+        if who is None:
+            who = ctx.author
+            subject_verb = f"{tag(who)} is"
+        if who.id in self.bot.registered_users:
+            await ctx.send(f"✅ {subject_verb} are currently registered with Parrot.")
         else:
-            await ctx.send("❌ You are not currently registered with Parrot.")
+            await ctx.send(f"❌ {subject_verb} not currently registered with Parrot.")
 
 
 async def setup(bot: Parrot) -> None:

--- a/commands/registration.py
+++ b/commands/registration.py
@@ -110,6 +110,8 @@ class Registration(commands.Cog):
         if who is None:
             who = ctx.author
         subject_verb = "You are" if who.id == ctx.author.id else f"{tag(who)} is"
+        if who.bot:
+            await ctx.send("✅ Bots do not need to be registered.")
         if who.id in self.bot.registered_users:
             await ctx.send(f"✅ {subject_verb} are currently registered with Parrot.")
         else:

--- a/commands/registration.py
+++ b/commands/registration.py
@@ -109,7 +109,7 @@ class Registration(commands.Cog):
         """
         if who is None:
             who = ctx.author
-        subject_verb = "You are" if who.id == ctx.author.id else f"{tag(who)} is"
+        subject_verb = "You are" if who.id == ctx.author.id else f"{who.mention} is"
         if who.bot:
             return await ctx.send("✅ Bots do not need to be registered.")
         if who.id in self.bot.registered_users:

--- a/commands/registration.py
+++ b/commands/registration.py
@@ -107,10 +107,9 @@ class Registration(commands.Cog):
         You need to be registered for Parrot to be able to analyze your messages
         and imitate you.
         """
-        subject_verb = "You are"
         if who is None:
             who = ctx.author
-            subject_verb = f"{tag(who)} is"
+        subject_verb = "You are" if who.id == ctx.author.id else f"{tag(who)} is"
         if who.id in self.bot.registered_users:
             await ctx.send(f"✅ {subject_verb} are currently registered with Parrot.")
         else:

--- a/commands/registration.py
+++ b/commands/registration.py
@@ -111,7 +111,7 @@ class Registration(commands.Cog):
             who = ctx.author
         subject_verb = "You are" if who.id == ctx.author.id else f"{tag(who)} is"
         if who.bot:
-            await ctx.send("✅ Bots do not need to be registered.")
+            return await ctx.send("✅ Bots do not need to be registered.")
         if who.id in self.bot.registered_users:
             await ctx.send(f"✅ {subject_verb} are currently registered with Parrot.")
         else:

--- a/commands/registration.py
+++ b/commands/registration.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 from bot import Parrot
-from utils import ParrotEmbed, tag
+from utils import ParrotEmbed
 from utils.converters import Userlike
 from utils.exceptions import FriendlyError
 
@@ -43,7 +43,7 @@ class Registration(commands.Cog):
         embed.add_field(
             name="Tip:",
             value=(
-               f"Try the `{self.bot.command_prefix}quickstart` command to "
+                f"Try the `{self.bot.command_prefix}quickstart` command to "
                 "immediately give Parrot a dataset to imitate you from! It "
                 "will scan your past messages to create a model of how you "
                 "speak so you can start using Parrot right away."

--- a/commands/text.py
+++ b/commands/text.py
@@ -103,12 +103,14 @@ class Text(commands.Cog):
     @commands.cooldown(2, 2, commands.BucketType.user)
     async def imitate(self, ctx: commands.Context, user: Userlike) -> None:
         """ Imitate someone. """
+        logging.info(f"Imitating {user}")
         await self.really_imitate(ctx, user, intimidate=False)
 
     @commands.command(brief="IMITATE SOMEONE.", hidden=True)
     @commands.cooldown(2, 2, commands.BucketType.user)
     async def intimidate(self, ctx: commands.Context, user: Userlike) -> None:
         """ IMITATE SOMEONE. """
+        logging.info(f"Intimidating {user}")
         await self.really_imitate(ctx, user, intimidate=True)
 
 

--- a/commands/text.py
+++ b/commands/text.py
@@ -64,7 +64,7 @@ class Text(commands.Cog):
         # Fetch this user's model.
         # May throw a NotRegistered or NoData error, which we'll just let the
         # error handler deal with.
-        model = await self.bot.get_model(user.id)
+        model = await self.bot.get_model(user)
         sentence = model.make_short_sentence(500) or "Error"
         name = f"Not {user.display_name}"
 

--- a/database/avatar_manager.py
+++ b/database/avatar_manager.py
@@ -47,7 +47,9 @@ class AvatarManager:
             # User hasn't changed their avatar since last time they did
             # |imitate, so we can use the cached modified avatar.
             if self._avatar_url_id(user.display_avatar.url) == self._avatar_url_id(original_avatar_url):
+                logging.debug("[AVATARS] CACHE HIT")
                 return modified_avatar_url
+            logging.debug("[AVATARS] CACHE MISS; data is not None")
 
             # Else, user has changed their avatar.
             # Respect the user's privacy by deleting the message with their old
@@ -56,6 +58,8 @@ class AvatarManager:
             asyncio.create_task(
                 self._delete_message(avatar_channel, modified_avatar_message_id)
             )
+        else:
+            logging.debug("[AVATARS] CACHE MISS; data is none")
 
         # User has changed their avatar since last time they did |imitate or has
         # not done |imitate before, so we must create a modified version of

--- a/database/avatar_manager.py
+++ b/database/avatar_manager.py
@@ -7,6 +7,7 @@ from discord import File, TextChannel, User
 from discord.errors import NotFound
 import config
 from utils.image import modify_avatar
+from utils import tag
 
 
 class AvatarManager:
@@ -47,9 +48,9 @@ class AvatarManager:
             # User hasn't changed their avatar since last time they did
             # |imitate, so we can use the cached modified avatar.
             if self._avatar_url_id(user.display_avatar.url) == self._avatar_url_id(original_avatar_url):
-                logging.debug("[AVATARS] CACHE HIT")
+                logging.debug(f"[AVATARS] CACHE HIT {tag(user)}")
                 return modified_avatar_url
-            logging.debug("[AVATARS] CACHE MISS; data is not None")
+            logging.debug(f"[AVATARS] CACHE MISS {tag(user)}; data is not None")
 
             # Else, user has changed their avatar.
             # Respect the user's privacy by deleting the message with their old
@@ -59,7 +60,7 @@ class AvatarManager:
                 self._delete_message(avatar_channel, modified_avatar_message_id)
             )
         else:
-            logging.debug("[AVATARS] CACHE MISS; data is none")
+            logging.debug(f"[AVATARS] CACHE MISS {tag(user)}; data is none")
 
         # User has changed their avatar since last time they did |imitate or has
         # not done |imitate before, so we must create a modified version of

--- a/database/avatar_manager.py
+++ b/database/avatar_manager.py
@@ -48,9 +48,9 @@ class AvatarManager:
             # User hasn't changed their avatar since last time they did
             # |imitate, so we can use the cached modified avatar.
             if self._avatar_url_id(user.display_avatar.url) == self._avatar_url_id(original_avatar_url):
-                logging.debug(f"[AVATARS] CACHE HIT {tag(user)}")
+                logging.info(f"[AVATARS] CACHE HIT {tag(user)}")
                 return modified_avatar_url
-            logging.debug(f"[AVATARS] CACHE MISS {tag(user)}; data is not None")
+            logging.info(f"[AVATARS] CACHE MISS {tag(user)}; data is not None")
 
             # Else, user has changed their avatar.
             # Respect the user's privacy by deleting the message with their old
@@ -60,7 +60,7 @@ class AvatarManager:
                 self._delete_message(avatar_channel, modified_avatar_message_id)
             )
         else:
-            logging.debug(f"[AVATARS] CACHE MISS {tag(user)}; data is none")
+            logging.info(f"[AVATARS] CACHE MISS {tag(user)}; data is none")
 
         # User has changed their avatar since last time they did |imitate or has
         # not done |imitate before, so we must create a modified version of

--- a/database/avatar_manager.py
+++ b/database/avatar_manager.py
@@ -48,9 +48,7 @@ class AvatarManager:
             # User hasn't changed their avatar since last time they did
             # |imitate, so we can use the cached modified avatar.
             if self._avatar_url_id(user.display_avatar.url) == self._avatar_url_id(original_avatar_url):
-                logging.info(f"[AVATARS] CACHE HIT {tag(user)}")
                 return modified_avatar_url
-            logging.info(f"[AVATARS] CACHE MISS {tag(user)}; data is not None")
 
             # Else, user has changed their avatar.
             # Respect the user's privacy by deleting the message with their old
@@ -59,8 +57,6 @@ class AvatarManager:
             asyncio.create_task(
                 self._delete_message(avatar_channel, modified_avatar_message_id)
             )
-        else:
-            logging.info(f"[AVATARS] CACHE MISS {tag(user)}; data is none")
 
         # User has changed their avatar since last time they did |imitate or has
         # not done |imitate before, so we must create a modified version of

--- a/database/corpus_manager.py
+++ b/database/corpus_manager.py
@@ -119,6 +119,6 @@ class CorpusManager:
     def assert_registered(self, user: Union[User, Member]) -> None:
         if not user.bot and user.id not in self.get_registered_users():
             raise NotRegisteredError(
-                f"User {user} is not opted in to Parrot. To opt in, do the "
-                f"`{self.command_prefix}register` command."
+                f"User {user.mention} is not opted in to Parrot. To opt in, do "
+                f"the `{self.command_prefix}register` command."
             )

--- a/database/corpus_manager.py
+++ b/database/corpus_manager.py
@@ -120,5 +120,5 @@ class CorpusManager:
         if not user.bot and user.id not in self.get_registered_users():
             raise NotRegisteredError(
                 f"User {user} is not opted in to Parrot. To opt in, do the "
-                f"`{self.bot.command_prefix}register` command."
+                f"`{self.command_prefix}register` command."
             )


### PR DESCRIPTION
Oops! get_model wasn't asserting the user it was getting the corpus for was registered. If a user had a corpus but was not registered, the imitate command would go through even though it shouldn't. This fixes that.

I noticed this error because this was actually causing a funny bug with the avatar system since it didn't expect unregistered users to ever be able to be imitated and when that was happening it was causing unintended behavior. Hence the name of the branch